### PR TITLE
Replaced AppCompatActivity with FragmentActivity

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -10,6 +10,9 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme">
+        <activity
+            android:name=".MyFragmentActivity"
+            android:exported="false" />
         <activity android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/app/src/main/java/com/codingtroops/screentracker/HelloWorldFragment.kt
+++ b/app/src/main/java/com/codingtroops/screentracker/HelloWorldFragment.kt
@@ -1,10 +1,12 @@
 package com.codingtroops.screentracker
 
+import android.content.Intent
 import android.os.Bundle
 import androidx.fragment.app.Fragment
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import android.widget.Button
 
 
 class HelloWorldFragment : Fragment() {
@@ -13,7 +15,13 @@ class HelloWorldFragment : Fragment() {
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View? {
-        return inflater.inflate(R.layout.fragment_hello_world, container, false)
+        val view = inflater.inflate(R.layout.fragment_hello_world, container, false)
+
+        view.findViewById<Button>(R.id.btnOpenActivity).setOnClickListener {
+            startActivity(Intent(requireActivity(), MyFragmentActivity::class.java))
+        }
+
+        return view
     }
 
 }

--- a/app/src/main/java/com/codingtroops/screentracker/MyFragmentActivity.kt
+++ b/app/src/main/java/com/codingtroops/screentracker/MyFragmentActivity.kt
@@ -1,0 +1,11 @@
+package com.codingtroops.screentracker
+
+import android.os.Bundle
+import androidx.fragment.app.FragmentActivity
+
+class MyFragmentActivity : FragmentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContentView(R.layout.activity_my_fragment)
+    }
+}

--- a/app/src/main/res/layout/activity_my_fragment.xml
+++ b/app/src/main/res/layout/activity_my_fragment.xml
@@ -1,0 +1,15 @@
+<?xml version="1.0" encoding="utf-8"?>
+<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    xmlns:tools="http://schemas.android.com/tools"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    tools:context=".MyFragmentActivity">
+
+    <TextView
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="center"
+        android:text="Hello Again!"/>
+
+</FrameLayout>

--- a/app/src/main/res/layout/fragment_hello_world.xml
+++ b/app/src/main/res/layout/fragment_hello_world.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
-<FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
+    android:orientation="vertical"
+    android:gravity="center"
     android:background="@android:color/darker_gray"
     tools:context=".HelloWorldFragment">
 
@@ -13,4 +15,11 @@
         android:layout_gravity="center"
         android:text="Hello world" />
 
-</FrameLayout>
+    <Button
+        android:id="@+id/btnOpenActivity"
+        android:layout_marginTop="16dp"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="Open Fragment Activity"/>
+
+</LinearLayout>

--- a/screentracker/src/main/java/com/codingtroops/screentracker/ScreenTracker.kt
+++ b/screentracker/src/main/java/com/codingtroops/screentracker/ScreenTracker.kt
@@ -84,7 +84,7 @@ object ScreenTracker {
     private fun listenForResumedActivities(activity: Activity) {
         sendScreenDetails(activity.javaClass, null)
         if (configuration.trackFragments)
-            (activity as FragmentActivity?)?.supportFragmentManager?.registerFragmentLifecycleCallbacks(
+            (activity as? FragmentActivity)?.supportFragmentManager?.registerFragmentLifecycleCallbacks(
                 object : FragmentManager.FragmentLifecycleCallbacks() {
                     override fun onFragmentResumed(fm: FragmentManager, f: Fragment) {
                         super.onFragmentResumed(fm, f)

--- a/screentracker/src/main/java/com/codingtroops/screentracker/ScreenTracker.kt
+++ b/screentracker/src/main/java/com/codingtroops/screentracker/ScreenTracker.kt
@@ -10,6 +10,7 @@ import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import androidx.core.content.ContextCompat.startForegroundService
 import androidx.fragment.app.Fragment
+import androidx.fragment.app.FragmentActivity
 import androidx.fragment.app.FragmentManager
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleObserver
@@ -83,7 +84,7 @@ object ScreenTracker {
     private fun listenForResumedActivities(activity: Activity) {
         sendScreenDetails(activity.javaClass, null)
         if (configuration.trackFragments)
-            (activity as AppCompatActivity?)?.supportFragmentManager?.registerFragmentLifecycleCallbacks(
+            (activity as FragmentActivity?)?.supportFragmentManager?.registerFragmentLifecycleCallbacks(
                 object : FragmentManager.FragmentLifecycleCallbacks() {
                     override fun onFragmentResumed(fm: FragmentManager, f: Fragment) {
                         super.onFragmentResumed(fm, f)


### PR DESCRIPTION
Library crash when used on acitivities that don't extend AppCompatActivity. For example, when an acitivity, that extends FragmentActivity directly, is navigated with ScreenTracker enabled, it used to crash becuase of the AppCompatActivity cast. Replaced AppCompatActivity with FragmentActivity to generalize its usage.
